### PR TITLE
security: remove wee_aloc

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,8 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
       - name: Install cargo-make
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [profile.release]
-# lto = true
-# opt-level = 'z'
-# strip = true
-# panic = 'abort'
-# codegen-units = 1
+lto = true
+opt-level = 'z'
+strip = true
+panic = 'abort'
+codegen-units = 1
 
 [features]
 default = ["rustls", "kv-mem", "kv-speedb", "remote"]
-wasm = ["rustls", "kv-mem", "kv-indxdb", "remote", "wee_alloc"]
+wasm = ["rustls", "kv-mem", "kv-indxdb", "remote"]
 remote = ["surrealdb/protocol-ws", "surrealdb/protocol-http"]
 kv-indxdb = ["surrealdb/kv-indxdb"]
 kv-speedb = ["surrealdb/kv-speedb"]
@@ -26,11 +26,9 @@ rustls = ["surrealdb/rustls"]
 [dependencies]
 async-trait = "0.1.73"
 serde = { version = "1.0.183", features = ["derive"] }
-serde_json = { version = "1.0.105", features = ["raw_value"] }
 thiserror = "1.0.47"
 surrealdb = { version = "1.1.1", default-features = false }
 # tokio = { version = "1.32.0", features = ["time", "macros"] }
-serde_cbor = "0.11.2"
 from_variants = "1.0.2"
 libipld-cbor = "0.16.0"
 libipld-core = { version = "0.16.0", features = [
@@ -38,10 +36,11 @@ libipld-core = { version = "0.16.0", features = [
     "serde-codec",
     "multibase",
 ] }
+libipld = { version = "0.16.0", features = ["serde-codec"] }
 chrono = { version = "0.4.30", features = ["serde"] }
 multihash = { version = "0.19.1", features = ["serde", "serde-codec"] }
 cid = { version = "0.11.0", features = ["serde-codec", "serde", "alloc"] }
-libipld = { version = "0.16.0", features = ["serde-codec"] }
+
 #[target.'cfg(target_family = "wasm")'.dependencies]
 web-sys = { version = "0.3.64", features = [
     "AbortSignal",
@@ -59,8 +58,6 @@ wasm-bindgen-futures = "0.4.37"
 serde-wasm-bindgen = "0.5.0"
 js-sys = "0.3.64"
 console_error_panic_hook = "0.1.7"
-wee_alloc = { version = "0.4.5", optional = true }
-cfg-if = "1.0.0"
 serde-aux = "4.2.0"
 serde_repr = "0.1.17"
 serde_with = "3.4.0"

--- a/src/js/mod.rs
+++ b/src/js/mod.rs
@@ -15,16 +15,7 @@ use web_sys::AbortSignal;
 
 extern crate console_error_panic_hook;
 
-use cfg_if::cfg_if;
-
 use self::query::{JSMessageSort, JSPagination, JSQueryReturn};
-
-cfg_if! {
-    if #[cfg(feature = "wee_alloc")] {
-        #[global_allocator]
-        static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-    }
-}
 
 const MESSAGE_STORE_OPTIONS_IMPORT: &'static str =
     r#"import { MessageStoreOptions } from "@tbd54566975/dwn-sdk-js";"#;


### PR DESCRIPTION
[wee_alloc](https://github.com/advisories/GHSA-rc23-xxgq-x27g) is no longer maintained. Remove it from the WASM build, and use the default allocator.